### PR TITLE
[BUGFIX] Invalid event reconstitution at EventStore::readEventBatch

### DIFF
--- a/src/EventStore.php
+++ b/src/EventStore.php
@@ -155,11 +155,13 @@ final class EventStore implements EventStoreInterface
 
         return array_map(
             function ($response) {
-                return $this
-                    ->createEventFromResponseContent(
-                        json_decode($response->getBody(), true)['content']
-                    )
-                ;
+                $data = json_decode($response->getBody(), true);
+                if (!isset($data['content'])) {
+                    return null;
+                }
+                return $this->createEventFromResponseContent(
+                    $data['content']
+                );
             },
             $responses
         );

--- a/src/StreamFeed/StreamFeedIterator.php
+++ b/src/StreamFeed/StreamFeedIterator.php
@@ -143,15 +143,23 @@ final class StreamFeedIterator implements \Iterator
         );
 
         $this->innerIterator = new ArrayIterator(
-            array_map(
-                function ($entry, $event) {
-                    return new EntryWithEvent(
-                        $entry,
-                        $event
-                    );
-                },
-                $entries,
-                $this->eventStore->readEventBatch($urls)
+            array_filter(
+                array_map(
+                    function ($entry, $event) {
+                        if ($entry === null || $event === null) {
+                            return null;
+                        }
+                        return new EntryWithEvent(
+                            $entry,
+                            $event
+                        );
+                    },
+                    $entries,
+                    $this->eventStore->readEventBatch($urls)
+                ),
+                function ($entryWithEvent) {
+                    return ($entryWithEvent !== null);
+                }
             )
         );
     }

--- a/tests/Tests/EventStoreTest.php
+++ b/tests/Tests/EventStoreTest.php
@@ -315,6 +315,27 @@ class EventStoreTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @test
+     */
+    public function it_can_process_the_all_stream_with_a_forward_iterator()
+    {
+        $client = new \GuzzleHttp\Client([
+            'auth' => ['admin', 'changeit'],
+            'handler' => new \GuzzleHttp\Handler\CurlMultiHandler(),
+        ]);
+        $httpClient = new GuzzleHttpClient($client);
+        $this->es = new EventStore('http://127.0.0.1:2113', $httpClient);
+
+        $this->prepareTestStream(1);
+        $streamName = rawurlencode('$all');
+
+        $this->assertGreaterThan(
+            0,
+            iterator_count($this->es->forwardStreamFeedIterator($streamName))
+        );
+    }
+
+    /**
      * @param  int    $length
      * @param  array  $metadata
      * @return string


### PR DESCRIPTION
In case of reading from the `$all` stream, not all events can be
handled like regular user-land events. That's also why some the
response data does not have and content defined. A fatal error is
issued after trying to recreate from `null`.