### PR TITLE
[TASK] Retrieve created version after writing to stream

### DIFF
--- a/tests/Tests/EventStoreTest.php
+++ b/tests/Tests/EventStoreTest.php
@@ -44,6 +44,18 @@ class EventStoreTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @test
+     */
+    public function version_is_provided_after_writing_to_stream()
+    {
+        $streamName = $this->prepareTestStream();
+        $event = WritableEvent::newInstance('Foo', ['foo' => 'bar']);
+
+        $version = $this->es->writeToStream($streamName, $event);
+        $this->assertSame(1, $version);
+    }
+
+    /**
+     * @test
      * @expectedException \EventStore\Exception\WrongExpectedVersionException
      */
     public function wrong_expected_version_should_throw_exception()


### PR DESCRIPTION
After an event has been written to a stream, the store responds
with an URI that reflects this new version. The proper way to
retrieve the version value would be to issue another request for
the new URI and extract the data. However, to reduce the amount
of round-trips the version is directly extracted from the first
HTTP Location header.

```
Location: http://127.0.0.1:2113/streams/newstream/13
```
... reflects version `13` of `newstream`